### PR TITLE
Fixing issue: Project type position in project detail page not justified correctly in mobile viewport #2

### DIFF
--- a/src/css/project.css
+++ b/src/css/project.css
@@ -15,6 +15,7 @@
 .project-type {
     margin-top: 15px;
     font-size: 0.9vw;
+    text-align: end;
 }
 
 .project-detail-description {
@@ -27,8 +28,7 @@
     display: block;
     margin-top: 25px !important;
     /* 貌似没啥diao用 x_x */
-    background: #efeeed url(../assets/images/Rolling-1s-200px.gif) no-repeat
-        center;
+    background: #efeeed url(../assets/images/Rolling-1s-200px.gif) no-repeat center;
     background-size: 64px;
 }
 


### PR DESCRIPTION
Fixes #2 

Description:
Added the fix for mis-alignment of **Project Type** on mobile widths

File formatted: **project.css**